### PR TITLE
support for long option (when int isn't enough)

### DIFF
--- a/src/main/java/com/headius/options/LongOption.java
+++ b/src/main/java/com/headius/options/LongOption.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.headius.options;
+
+/**
+ * A Long-based Option.
+ */
+public class LongOption extends Option<Long> {
+    public LongOption(String prefix, String name, Enum category, Long[] options, Long defval, String description) {
+        super(prefix, name, Long.class, category, options, defval, description);
+    }
+
+    public LongOption(String longName, Enum category, Long[] options, Long defval, String description) {
+        super(longName, Long.class, category, options, defval, description);
+    }
+
+    public LongOption(String prefix, String name, Enum category, Long defval, String description) {
+        super(prefix, name, Long.class, category, null, defval, description);
+    }
+
+    public LongOption(String longName, Enum category, Long defval, String description) {
+        super(longName, Long.class, category, null, defval, description);
+    }
+
+    public Long reloadValue() {
+        String value = super.loadProperty();
+
+        if (value == null) {
+            return defval;
+        }
+
+        return Long.parseLong(value);
+    }
+}

--- a/src/main/java/com/headius/options/Option.java
+++ b/src/main/java/com/headius/options/Option.java
@@ -229,7 +229,35 @@ public abstract class Option<T> {
     public static Option<Integer> integer(String longName, Enum category, Integer[] options, Integer defval, String description) {
         return new IntegerOption(longName, category, options, defval, description);
     }
-    
+
+    /**
+     * Create a new Long option with the given configuration.
+     */
+    public static Option<Long> longInt(String prefix, String name, Enum category, String description) {
+        return new LongOption(prefix, name, category, null, description);
+    }
+
+    /**
+     * Create a new Long option with the given configuration.
+     */
+    public static Option<Long> longInt(String longName, Enum category, String description) {
+        return new LongOption(longName, category, null, description);
+    }
+
+    /**
+     * Create a new Long option with the given configuration.
+     */
+    public static Option<Long> longInt(String prefix, String name, Enum category, Long defval, String description) {
+        return new LongOption(prefix, name, category, defval, description);
+    }
+
+    /**
+     * Create a new Long option with the given configuration.
+     */
+    public static Option<Long> longInt(String longName, Enum category, Long defval, String description) {
+        return new LongOption(longName, category, defval, description);
+    }
+
     /**
      * Create a new Enumeration-based option with the given configuration.
      */

--- a/src/test/java/com/headius/options/LongOptionTest.java
+++ b/src/test/java/com/headius/options/LongOptionTest.java
@@ -1,0 +1,41 @@
+package com.headius.options;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.*;
+
+public class LongOptionTest {
+    enum Category { TEST }
+
+    @Test
+    public void testValues() throws Exception {
+
+        LongOption opt = new LongOption("options.test.long", Category.TEST, 1L, "");
+
+        System.clearProperty("options.test.long");
+        assertEquals(Long.valueOf(1), opt.reloadValue());
+
+        System.setProperty("options.test.long", "0");
+        assertEquals(Long.valueOf(0), opt.reloadValue());
+
+        System.setProperty("options.test.long", "1000000000000000000");
+        assertEquals(Long.valueOf(1000000000000000000L), opt.reloadValue());
+
+        System.setProperty("options.test.long", "-2000000000000000000");
+        assertEquals(Long.valueOf(-2000000000000000000L), opt.reloadValue());
+    }
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    @Test
+    public void testInvalid() {
+        System.setProperty("options.test.long", "");
+        LongOption opt = new LongOption("options.test.long", Category.TEST, 1L, "");
+        exceptionRule.expect(NumberFormatException.class);
+        opt.reloadValue();
+    }
+
+}


### PR DESCRIPTION
we might need this for specifying `jit.time.delta` is nano seconds (https://github.com/jruby/jruby/pull/5887)